### PR TITLE
Fix regexp in default interception filter

### DIFF
--- a/gui/interception_filters.py
+++ b/gui/interception_filters.py
@@ -51,7 +51,7 @@ class InterceptionFilters():
 
         # Adding some default interception filters
         # self.IFModel.addElement("Scope items only: (Content is not required)") # commented for better first impression.
-        self._extender.IFModel.addElement("URL Not Contains (regex): \\.js|\\.css|\\.png|\\.jpg|\\.svg|\\.jpeg|\\.gif|\\.woff|\\.map|\\.bmp|\\.ico$")
+        self._extender.IFModel.addElement("URL Not Contains (regex): (\\.js|\\.css|\\.png|\\.jpg|\\.svg|\\.jpeg|\\.gif|\\.woff|\\.map|\\.bmp|\\.ico)$")
         self._extender.IFModel.addElement("Ignore spider requests: ")
         
         self._extender.IFText = JTextArea("", 5, 30)

--- a/gui/interception_filters.py
+++ b/gui/interception_filters.py
@@ -51,7 +51,7 @@ class InterceptionFilters():
 
         # Adding some default interception filters
         # self.IFModel.addElement("Scope items only: (Content is not required)") # commented for better first impression.
-        self._extender.IFModel.addElement("URL Not Contains (regex): (\\.js|\\.css|\\.png|\\.jpg|\\.svg|\\.jpeg|\\.gif|\\.woff|\\.map|\\.bmp|\\.ico)$")
+        self._extender.IFModel.addElement("URL Not Contains (regex): (\\.js|\\.css|\\.png|\\.jpg|\\.svg|\\.jpeg|\\.gif|\\.woff|\\.map|\\.bmp|\\.ico)((\\?(v|ver|version)=)?[^=]+)?$")
         self._extender.IFModel.addElement("Ignore spider requests: ")
         
         self._extender.IFText = JTextArea("", 5, 30)


### PR DESCRIPTION
In original expression end of string symbol is checked only for .ico, in consequence matching much more URLs than intended.
For example, while testing Java Server Faces application (URLs ending with .jsf) all URLs will match expression `\.js` making user wonder why extension is not working at all.