### PR TITLE
Add ability to test all Header Profiles at once

### DIFF
--- a/authorization/authorization.py
+++ b/authorization/authorization.py
@@ -315,11 +315,12 @@ def checkAuthorization(self, messageInfo, originalHeaders, checkUnauthorized):
 
     row = self._log.size()
     method = self._helpers.analyzeRequest(messageInfo.getRequest()).getMethod()
+    selectedProfile = self.savedHeadersTitlesCombo.getSelectedItem()
 
     if checkUnauthorized:
-        self._log.add(LogEntry(self.currentRequestNumber,self._callbacks.saveBuffersToTempFiles(requestResponse), method, self._helpers.analyzeRequest(requestResponse).getUrl(),messageInfo,impression,self._callbacks.saveBuffersToTempFiles(requestResponseUnauthorized),impressionUnauthorized)) # same requests not include again.
+        self._log.add(LogEntry(self.currentRequestNumber,self._callbacks.saveBuffersToTempFiles(requestResponse), method, self._helpers.analyzeRequest(requestResponse).getUrl(),messageInfo,impression,self._callbacks.saveBuffersToTempFiles(requestResponseUnauthorized),impressionUnauthorized,selectedProfile)) # same requests not include again.
     else:
-        self._log.add(LogEntry(self.currentRequestNumber,self._callbacks.saveBuffersToTempFiles(requestResponse), method, self._helpers.analyzeRequest(requestResponse).getUrl(),messageInfo,impression,None,"Disabled")) # same requests not include again.
+        self._log.add(LogEntry(self.currentRequestNumber,self._callbacks.saveBuffersToTempFiles(requestResponse), method, self._helpers.analyzeRequest(requestResponse).getUrl(),messageInfo,impression,None,"Disabled",selectedProfile)) # same requests not include again.
 
     SwingUtilities.invokeLater(UpdateTableEDT(self,"insert",row,row))
     self.currentRequestNumber = self.currentRequestNumber + 1

--- a/gui/configuration_tab.py
+++ b/gui/configuration_tab.py
@@ -49,21 +49,25 @@ class ConfigurationTab():
         self._extender.doUnauthorizedRequest.setBounds(280, 65, 300, 30)
         self._extender.doUnauthorizedRequest.setSelected(True)
 
+        self._extender.doWithAllProfiles = JCheckBox("Check with all profiles")
+        self._extender.doWithAllProfiles.setBounds(280, 85, 300, 30)
+        self._extender.doWithAllProfiles.setSelected(False)
+
         self._extender.replaceQueryParam = JCheckBox("Replace query params", actionPerformed=self.replaceQueryHanlder)
-        self._extender.replaceQueryParam.setBounds(280, 85, 300, 30)
+        self._extender.replaceQueryParam.setBounds(280, 105, 300, 30)
         self._extender.replaceQueryParam.setSelected(False)
 
         self._extender.saveHeadersButton = JButton("Add",
                                         actionPerformed=self.saveHeaders)
-        self._extender.saveHeadersButton.setBounds(315, 115, 80, 30)
+        self._extender.saveHeadersButton.setBounds(315, 135, 80, 30)
 
         self._extender.updateHeadersButton = JButton("Update",
                                         actionPerformed=self.updateHeaders)
-        self._extender.updateHeadersButton.setBounds(400, 115, 80, 30)
-        
+        self._extender.updateHeadersButton.setBounds(400, 135, 80, 30)
+
         self._extender.removeHeadersButton = JButton("Remove",
                                         actionPerformed=self.removeHeaders)
-        self._extender.removeHeadersButton.setBounds(485, 115, 80, 30)
+        self._extender.removeHeadersButton.setBounds(485, 135, 80, 30)
 
         savedHeadersTitles = self.getSavedHeadersTitles()
         self._extender.savedHeadersTitlesCombo = JComboBox(savedHeadersTitles)
@@ -188,6 +192,12 @@ class ConfigurationTab():
                             GroupLayout.PREFERRED_SIZE,
                         )
                         .addComponent(
+                            self._extender.doWithAllProfiles,
+                            GroupLayout.PREFERRED_SIZE,
+                            GroupLayout.PREFERRED_SIZE,
+                            GroupLayout.PREFERRED_SIZE,
+                        )
+                        .addComponent(
                             self._extender.autoScroll,
                             GroupLayout.PREFERRED_SIZE,
                             GroupLayout.PREFERRED_SIZE,
@@ -251,6 +261,12 @@ class ConfigurationTab():
                     )
                     .addComponent(
                         self._extender.doUnauthorizedRequest,
+                        GroupLayout.PREFERRED_SIZE,
+                        GroupLayout.PREFERRED_SIZE,
+                        GroupLayout.PREFERRED_SIZE,
+                    )
+                    .addComponent(
+                        self._extender.doWithAllProfiles,
                         GroupLayout.PREFERRED_SIZE,
                         GroupLayout.PREFERRED_SIZE,
                         GroupLayout.PREFERRED_SIZE,

--- a/gui/configuration_tab.py
+++ b/gui/configuration_tab.py
@@ -56,10 +56,14 @@ class ConfigurationTab():
         self._extender.saveHeadersButton = JButton("Add",
                                         actionPerformed=self.saveHeaders)
         self._extender.saveHeadersButton.setBounds(315, 115, 80, 30)
+
+        self._extender.updateHeadersButton = JButton("Update",
+                                        actionPerformed=self.updateHeaders)
+        self._extender.updateHeadersButton.setBounds(400, 115, 80, 30)
         
         self._extender.removeHeadersButton = JButton("Remove",
                                         actionPerformed=self.removeHeaders)
-        self._extender.removeHeadersButton.setBounds(400, 115, 80, 30)
+        self._extender.removeHeadersButton.setBounds(485, 115, 80, 30)
 
         savedHeadersTitles = self.getSavedHeadersTitles()
         self._extender.savedHeadersTitlesCombo = JComboBox(savedHeadersTitles)
@@ -202,6 +206,12 @@ class ConfigurationTab():
                             GroupLayout.PREFERRED_SIZE,
                         )
                         .addComponent(
+                            self._extender.updateHeadersButton,
+                            GroupLayout.PREFERRED_SIZE,
+                            GroupLayout.PREFERRED_SIZE,
+                            GroupLayout.PREFERRED_SIZE,
+                        )
+                        .addComponent(
                             self._extender.removeHeadersButton,
                             GroupLayout.PREFERRED_SIZE,
                             GroupLayout.PREFERRED_SIZE,
@@ -280,6 +290,12 @@ class ConfigurationTab():
                             GroupLayout.PREFERRED_SIZE,
                         )
                         .addComponent(
+                            self._extender.updateHeadersButton,
+                            GroupLayout.PREFERRED_SIZE,
+                            GroupLayout.PREFERRED_SIZE,
+                            GroupLayout.PREFERRED_SIZE,
+                        )
+                        .addComponent(
                             self._extender.removeHeadersButton,
                             GroupLayout.PREFERRED_SIZE,
                             GroupLayout.PREFERRED_SIZE,
@@ -348,6 +364,16 @@ class ConfigurationTab():
         self._extender.savedHeadersTitlesCombo.setModel(DefaultComboBoxModel(self.getSavedHeadersTitles()))
         self._extender.savedHeadersTitlesCombo.getModel().setSelectedItem(savedHeadersTitle)
     
+    def updateHeaders(self, event):
+        model = self._extender.savedHeadersTitlesCombo.getModel()
+        selectedItem = model.getSelectedItem()
+        if selectedItem == "Temporary headers":
+            return
+
+        for headerObj in self._extender.savedHeaders:
+            if selectedItem == headerObj['title']:
+                headerObj['headers'] = self._extender.replaceString.getText()
+
     def removeHeaders(self, event):
         model = self._extender.savedHeadersTitlesCombo.getModel()
         selectedItem = model.getSelectedItem()

--- a/gui/table.py
+++ b/gui/table.py
@@ -226,18 +226,18 @@ class TableModel(AbstractTableModel):
             return 0
 
     def getColumnCount(self):
-        return 8
+        return 9
 
     def getColumnName(self, columnIndex):
-        data = ['ID','Method', 'URL', 'Orig. Len', 'Modif. Len', "Unauth. Len",
-                "Authz. Status", "Unauth. Status"]
+        data = ['ID','Method', 'URL', 'Orig. Len', 'Modif. Len', 'Unauth. Len',
+                "Authz. Status", 'Unauth. Status', 'Profile']
         try:
             return data[columnIndex]
         except IndexError:
             return ""
 
     def getColumnClass(self, columnIndex):
-        data = [Integer, String, String, Integer, Integer, Integer, String, String]
+        data = [Integer, String, String, Integer, Integer, Integer, String, String, String]
         try:
             return data[columnIndex]
         except IndexError:
@@ -266,7 +266,9 @@ class TableModel(AbstractTableModel):
         if columnIndex == 6:
             return logEntry._enfocementStatus   
         if columnIndex == 7:
-            return logEntry._enfocementStatusUnauthorized        
+            return logEntry._enfocementStatusUnauthorized
+        if columnIndex == 8:
+            return logEntry._profile
         return ""
 
 class TableSelectionListener(ListSelectionListener):
@@ -351,7 +353,7 @@ class Table(JTable):
         return
 
 class LogEntry:
-    def __init__(self, id, requestResponse, method, url, originalrequestResponse, enforcementStatus, unauthorizedRequestResponse, enforcementStatusUnauthorized):
+    def __init__(self, id, requestResponse, method, url, originalrequestResponse, enforcementStatus, unauthorizedRequestResponse, enforcementStatusUnauthorized, profile):
         self._id = id
         self._requestResponse = requestResponse
         self._originalrequestResponse = originalrequestResponse
@@ -360,6 +362,7 @@ class LogEntry:
         self._enfocementStatus =  enforcementStatus
         self._unauthorizedRequestResponse = unauthorizedRequestResponse
         self._enfocementStatusUnauthorized =  enforcementStatusUnauthorized
+        self._profile = profile
         return
 
 class Mouseclick(MouseAdapter):

--- a/gui/tabs.py
+++ b/gui/tabs.py
@@ -118,6 +118,12 @@ class Tabs():
 
         retestAllitem = JMenuItem("Retest all requests")
         retestAllitem.addActionListener(RetestAllRequests(self._extender))
+
+        retestSelecteditemWithAllProfiles = JMenuItem("Retest selected request (all profiles)")
+        retestSelecteditemWithAllProfiles.addActionListener(RetestSelectedRequest(self._extender, True))
+
+        retestAllitemWithAllProfiles = JMenuItem("Retest all requests (all profiles)")
+        retestAllitemWithAllProfiles.addActionListener(RetestAllRequests(self._extender, True))
         
         deleteSelectedItem = JMenuItem("Delete")
         deleteSelectedItem.addActionListener(DeleteSelectedRequest(self._extender))
@@ -129,6 +135,8 @@ class Tabs():
         self._extender.menu.add(copyURLitem)
         self._extender.menu.add(retestSelecteditem)
         self._extender.menu.add(retestAllitem)
+        self._extender.menu.add(retestSelecteditemWithAllProfiles)
+        self._extender.menu.add(retestAllitemWithAllProfiles)
         self._extender.menu.add(deleteSelectedItem) # disabling this feature until bug will be fixed.
         message_editor = MessageEditor(self._extender)
 
@@ -210,18 +218,20 @@ class SendResponseComparer(ActionListener):
 
 
 class RetestSelectedRequest(ActionListener):
-    def __init__(self, extender):
+    def __init__(self, extender, checkWithAllProfiles=False):
         self._extender = extender
+        self._checkWithAllProfiles = checkWithAllProfiles
 
     def actionPerformed(self, e):
-        start_new_thread(handle_message, (self._extender, "AUTORIZE", False, self._extender._currentlyDisplayedItem._originalrequestResponse))
+        start_new_thread(handle_message, (self._extender, "AUTORIZE", False, self._extender._currentlyDisplayedItem._originalrequestResponse, self._checkWithAllProfiles))
 
 class RetestAllRequests(ActionListener):
-    def __init__(self, extender):
+    def __init__(self, extender, checkWithAllProfiles=False):
         self._extender = extender
+        self._checkWithAllProfiles = checkWithAllProfiles
 
     def actionPerformed(self, e):
-        start_new_thread(retestAllRequests, (self._extender,))
+        start_new_thread(retestAllRequests, (self._extender, self._checkWithAllProfiles))
 
 
 class DeleteSelectedRequest(AbstractAction):

--- a/gui/tabs.py
+++ b/gui/tabs.py
@@ -62,6 +62,7 @@ class Tabs():
         self._extender.logTable.getColumn("Unauth. Len").setPreferredWidth(Math.round(tableWidth / 50 * 4))
         self._extender.logTable.getColumn("Authz. Status").setPreferredWidth(Math.round(tableWidth / 50 * 4))
         self._extender.logTable.getColumn("Unauth. Status").setPreferredWidth(Math.round(tableWidth / 50 * 4))
+        self._extender.logTable.getColumn("Profile").setPreferredWidth(Math.round(tableWidth / 50 * 4))
 
         self._extender.tableSorter = TableRowSorter(self._extender.tableModel)
         rowFilter = TableRowFilter(self._extender)

--- a/helpers/http.py
+++ b/helpers/http.py
@@ -20,15 +20,21 @@ def makeRequest(self, messageInfo, message):
     requestURL = self._helpers.analyzeRequest(messageInfo).getUrl()
     return self._callbacks.makeHttpRequest(self._helpers.buildHttpService(str(requestURL.getHost()), int(requestURL.getPort()), requestURL.getProtocol() == "https"), message)
 
-def makeMessage(self, messageInfo, removeOrNot, authorizeOrNot):
+def makeMessage(self, messageInfo, removeOrNot, authorizeOrNot, profile=None):
     requestInfo = self._helpers.analyzeRequest(messageInfo)
     headers = requestInfo.getHeaders()
+
+    if profile and 'headers' in profile:
+        replaceString = profile['headers']
+    else:
+        replaceString = self.replaceString.getText()
+
     if removeOrNot:
         headers = list(headers)
         # flag for query
         queryFlag = self.replaceQueryParam.isSelected()
         if queryFlag:
-            param = self.replaceString.getText().split("=")
+            param = replaceString.split("=")
             paramKey = param[0]
             paramValue = param[1]
             # ([\?&])test=.*?(?=[\s&])
@@ -36,7 +42,7 @@ def makeMessage(self, messageInfo, removeOrNot, authorizeOrNot):
             patchedHeader = re.sub(pattern, r"\1{}={}".format(paramKey, paramValue), headers[0], count=1, flags=re.DOTALL)
             headers[0] = patchedHeader
         else:
-            removeHeaders = self.replaceString.getText()
+            removeHeaders = replaceString
 
             # Headers must be entered line by line i.e. each header in a new
             # line
@@ -57,7 +63,7 @@ def makeMessage(self, messageInfo, removeOrNot, authorizeOrNot):
 
             if not queryFlag:
                 # fix missing carriage return on *NIX systems
-                replaceStringLines = self.replaceString.getText().split("\n")
+                replaceStringLines = replaceString.split("\n")
                 for h in replaceStringLines:
                     if h == "": # Logic to fix extraneous newline at the end of requests when no temporary headers are added
                         pass


### PR DESCRIPTION
I frequently encounter situations where the application under test includes multiple user roles, making it time-consuming to test each role individually. This update introduces several enhancements to streamline that workflow:

- **Test all header profiles at once:** You can now run tests against all configured header profiles by enabling the “Check with all profiles” option, or by right-clicking to retest either the selected request or all requests using the new “(all profiles)” actions. The logic is optimized so that if an unauthenticated check is enabled, it only sends one unauthenticated request, even when multiple profiles are used.

- **Log enhancement:** The header profile name is now included in each log row within the requests table.

- **Editable header profiles:** You can now update an existing header profile directly, instead of removing and re-adding it.
